### PR TITLE
run with space in path

### DIFF
--- a/src/test/java/io/jenkins/plugins/pipeline_elasticsearch_logs/testutils/ResourceUtils.java
+++ b/src/test/java/io/jenkins/plugins/pipeline_elasticsearch_logs/testutils/ResourceUtils.java
@@ -98,10 +98,9 @@ public class ResourceUtils
    */
   private static String readResource(String filePath) throws IOException {
     ClassLoader classLoader = ResourceUtils.class.getClassLoader();
-    URL resource = classLoader.getResource(filePath);
-    if(resource == null) throw new IOException("Could not find resource: " + filePath);
-    File file = new File(resource.getFile());
-    return FileUtils.readFileToString(file, "UTF-8");
+    InputStream in = classLoader.getResourceAsStream(filePath);
+    if (in == null) throw new IOException("Could not find resource: " + filePath);
+    return IOUtils.toString(in, StandardCharsets.UTF_8);
   }
 
 }


### PR DESCRIPTION
I have a space in my path. When converting from `URL` to `File` the path will have `%20`, which is wrong.

This implementation doesn't use `File` to read the content.